### PR TITLE
Changing the base url to point to the cloud api

### DIFF
--- a/frontend/src/api/axios.tsx
+++ b/frontend/src/api/axios.tsx
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 export default axios.create({
-  baseURL: "http://localhost:8081",
+  baseURL: "https://sep6-api.tomondre.com",
   headers: {
     "Content-type": "application/json",
   },


### PR DESCRIPTION
Will decrease load time and you do not need to run the backend on your computer anymore, only frontend for development